### PR TITLE
Fix environment typos

### DIFF
--- a/pages/why.mdx
+++ b/pages/why.mdx
@@ -3,7 +3,7 @@
 That's a fair question you might be asking yourself. Why do we even need starknet app-chains in the first place ? 
 Shouldn't Starknet be sufficient for most use cases ? How do we deal with liquidity and state fragmentation ?
 
-Every application has their own needs and specifities which deserve their own execution envirronement.
+Every application has their own needs and specifities which deserve their own execution environment.
 This has been coined as **AppEtite** by Gideon Kampfer and sheds light on all the different needs applications could have : 
 - Privacy
 - TPS > 10/sec
@@ -42,7 +42,7 @@ Throughput will not be impacted by activity of other applications, that means wh
 ## Better Control
 
 Starknet itself and any general-purpose chain has to put boundaries in order to prevent DOS attacks and make the network usable to everyone.
-However, this is not true anymore if the execution envirronement is solely yours : 
+However, this is not true anymore if the execution environment is solely yours : 
 - Public access to controlled contracts with specific logic. 
 If you don't like the limits of the Cairo VM, all good, just get rid of them in your custom Starknet!
 Want better scalability ? Missing hints ? Again, feel no worries, you can just execute cairo programs hardcoded into your chain and write Cairo 0 programs! 


### PR DESCRIPTION
There were two typos in the "why" page