### PR TITLE
fixing meta.json for dev flag

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -24,7 +24,7 @@
   "config": "Configure",
   "protocol-config": "Protocol Configuration",
   "chain-id": "Chain ID",
-  "dev": "Madara with the --dev flag",
+  "dev-mode": "Madara with the --dev flag",
   "tutorial": "Dapp Tutorial",
   "da-layer": "Data Availability",
   "tools": "Tooling",


### PR DESCRIPTION
the meta.json file had an incorrect key for the --dev flag page

this GMR resolves that